### PR TITLE
Add Sec-CH-UA-Wow64 to `HttpHeaders`.

### DIFF
--- a/android/guava-tests/test/com/google/common/net/HttpHeadersTest.java
+++ b/android/guava-tests/test/com/google/common/net/HttpHeadersTest.java
@@ -40,6 +40,7 @@ public class HttpHeadersTest extends TestCase {
             .put("CDN_LOOP", "CDN-Loop")
             .put("ETAG", "ETag")
             .put("SOURCE_MAP", "SourceMap")
+            .put("SEC_CH_UA_WOW64", "Sec-CH-UA-WoW64")
             .put("SEC_WEBSOCKET_ACCEPT", "Sec-WebSocket-Accept")
             .put("SEC_WEBSOCKET_EXTENSIONS", "Sec-WebSocket-Extensions")
             .put("SEC_WEBSOCKET_KEY", "Sec-WebSocket-Key")

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -700,6 +700,13 @@ public final class HttpHeaders {
    */
   public static final String SEC_CH_UA_MOBILE = "Sec-CH-UA-Mobile";
   /**
+   * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-wow64">{@code
+   * Sec-CH-UA-WoW64}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_CH_UA_WOW64 = "Sec-CH-UA-WoW64";
+  /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-bitness">{@code
    * Sec-CH-UA-Bitness}</a> header field name.
    *

--- a/guava-tests/test/com/google/common/net/HttpHeadersTest.java
+++ b/guava-tests/test/com/google/common/net/HttpHeadersTest.java
@@ -40,6 +40,7 @@ public class HttpHeadersTest extends TestCase {
             .put("CDN_LOOP", "CDN-Loop")
             .put("ETAG", "ETag")
             .put("SOURCE_MAP", "SourceMap")
+            .put("SEC_CH_UA_WOW64", "Sec-CH-UA-WoW64")
             .put("SEC_WEBSOCKET_ACCEPT", "Sec-WebSocket-Accept")
             .put("SEC_WEBSOCKET_EXTENSIONS", "Sec-WebSocket-Extensions")
             .put("SEC_WEBSOCKET_KEY", "Sec-WebSocket-Key")

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -700,6 +700,13 @@ public final class HttpHeaders {
    */
   public static final String SEC_CH_UA_MOBILE = "Sec-CH-UA-Mobile";
   /**
+   * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-wow64">{@code
+   * Sec-CH-UA-WoW64}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_CH_UA_WOW64 = "Sec-CH-UA-WoW64";
+  /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-bitness">{@code
    * Sec-CH-UA-Bitness}</a> header field name.
    *


### PR DESCRIPTION
Spec: https://wicg.github.io/ua-client-hints/#sec-ch-ua-wow64

RELNOTES=`net`: Added `HttpHeaders` constant `Sec-CH-UA-Wow64`.
PiperOrigin-RevId: 471292642